### PR TITLE
fix: Correct package.json name and add vsce validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "extensionId": "co-edit",
-  "displayName": "vscode-co-edit",
+  "name": "co-edit",
+  "displayName": "Co-Edit",
   "description": "An AI academic writing co-pilot for VSCode.",
   "version": "0.0.1",
   "engines": {
@@ -52,7 +52,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run lint",
+    "pretest": "npm run compile && npm run lint && npx vsce package --no-dependencies",
     "lint": "eslint src --ext ts",
     "format": "prettier --write src/**/*.ts",
     "test": "vscode-test"
@@ -67,7 +67,8 @@
     "@vscode/test-electron": "^2.5.2",
     "eslint": "^9.30.0",
     "prettier": "^3.6.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vsce": "^2.15.0"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1"


### PR DESCRIPTION
This PR corrects the missing 'name' property in package.json, sets the displayName to 'Co-Edit', and adds vsce package validation to the pretest script to prevent future loading issues.