### PR TITLE
fix: Update Gemini model name to gemini-pro

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,3 +2,4 @@
 
 This file tracks issues and improvements for the project.
 
+- [x] [BUG] Fix Gemini API model not found error (closes #50)

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -10,7 +10,7 @@ export async function generateContent(secretStorage: vscode.SecretStorage, promp
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: "gemini-1.0-pro"});
+    const model = genAI.getGenerativeModel({ model: "gemini-pro"});
 
     try {
         const result = await model.generateContent(prompt);


### PR DESCRIPTION
This PR updates the Gemini model name from  to  in  to resolve the  error when generating content. (closes #50)