### PR TITLE
fix: Update Gemini model name to gemini-1.5-pro

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,3 +3,4 @@
 This file tracks issues and improvements for the project.
 
 - [x] [BUG] Fix Gemini API model not found error (closes #50)
+- [x] [BUG] Gemini API model 'gemini-pro' not found (closes #52)

--- a/src/gemini.ts
+++ b/src/gemini.ts
@@ -10,7 +10,7 @@ export async function generateContent(secretStorage: vscode.SecretStorage, promp
     }
 
     const genAI = new GoogleGenerativeAI(apiKey);
-    const model = genAI.getGenerativeModel({ model: "gemini-pro"});
+    const model = genAI.getGenerativeModel({ model: "gemini-1.5-pro"});
 
     try {
         const result = await model.generateContent(prompt);


### PR DESCRIPTION
This PR updates the Gemini model name from  to  in  to resolve the  error when generating content. (closes #52)