### PR TITLE
feat: Add accept/discard functionality to Improve Paragraph command

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,3 +5,4 @@ This file tracks issues and improvements for the project.
 - [x] [BUG] Fix Gemini API model not found error (closes #50)
 - [x] [FEAT] Update Google Generative AI library to latest version (closes #54)
 - [x] [BUG] 'Improve Paragraph' command fails with ENOPRO error (closes #56)
+- [x] [FEAT] Add accept/discard functionality to 'Improve Paragraph' (closes #58)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -260,7 +260,19 @@ export function activate(context: vscode.ExtensionContext) {
 
         await vscode.commands.executeCommand('vscode.diff', originalUri, improvedUri, 'Original vs. Improved Paragraph');
 
-        vscode.window.showInformationMessage('Improved paragraph displayed in diff view.');
+        const choice = await vscode.window.showQuickPick(['Accept', 'Discard'], {
+            placeHolder: 'Accept or discard the improved paragraph?',
+            ignoreFocusOut: true
+        });
+
+        if (choice === 'Accept') {
+            editor.edit(editBuilder => {
+                editBuilder.replace(selection, improvedText);
+            });
+            vscode.window.showInformationMessage('Improved paragraph accepted.');
+        } else {
+            vscode.window.showInformationMessage('Improved paragraph discarded.');
+        }
 	});
 
 	context.subscriptions.push(improveParagraphDisposable);


### PR DESCRIPTION
This PR adds accept/discard functionality to the 'Co-Edit: Improve Paragraph' command. After displaying the diff view, a Quick Pick will allow the user to accept the improved paragraph (replacing the original text) or discard it. (closes #58)